### PR TITLE
Automate AiVectra release packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,12 @@ on:
       - "release/**"
       - "hotfix/**"
       - "codex/**"
+    tags:
+      - "v*.*.*"
+      - "v*.*.*-*"
+
+permissions:
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -49,3 +55,39 @@ jobs:
           cp -R ./test-fixtures/. "$package_dir/test-fixtures/"
           cp ./README.md ./LICENSE "$package_dir/"
           "$package_dir/bin/aivectra" --help >/dev/null
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: aivectra-sdk-linux
+          path: .tmp/aivectra-ci-package
+
+  publish-release:
+    name: publish-release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs:
+      - sdk
+    permissions:
+      contents: write
+    steps:
+      - name: Download package artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: aivectra-sdk-linux
+          path: ./release-artifacts/aivectra-sdk-linux
+
+      - name: Package release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ./release-assets
+          (cd ./release-artifacts/aivectra-sdk-linux && tar -czf ../../release-assets/aivectra-sdk-linux.tar.gz .)
+          (cd ./release-assets && sha256sum *.tar.gz > SHA256SUMS.txt)
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./release-assets/*
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary

- run AiVectra CI on semantic version tags
- upload the smoke-tested SDK package as a CI artifact
- publish a GitHub Release on `v*.*.*` / `v*.*.*-*` tags after CI succeeds
- attach a packaged Linux SDK archive and SHA256 sums

## Release discipline

This is CI/CD-only. It does not change AiVectra semantics, source layout, or runtime behavior.