### PR TITLE
Publish deterministic package template catalogs

### DIFF
--- a/package.toml
+++ b/package.toml
@@ -1,6 +1,6 @@
 schema = "ailang.package-source.v1"
 name = "aivectra"
-version = "0.0.1-beta.15"
+version = "0.0.1-beta.16"
 types = ["library", "tool", "template"]
 
 [dependencies]

--- a/templates/files/index.toml
+++ b/templates/files/index.toml
@@ -1,0 +1,4 @@
+[[template]]
+name = "view-basic"
+description = "Reusable AiVectra view module."
+path = "templates/files/view-basic"

--- a/templates/projects/index.toml
+++ b/templates/projects/index.toml
@@ -1,0 +1,4 @@
+[[template]]
+name = "hello-name"
+description = "Minimal AiVectra application that greets a supplied name."
+path = "templates/projects/hello-name"


### PR DESCRIPTION
Adds package-owned indexes for AiVectra project and file templates and bumps the package descriptor to 0.0.1-beta.16.\n\nValidated: ./scripts/test-all.sh and package surface checks.